### PR TITLE
ガチ度のカラーパターン・文言、プラットフォームの定数作成

### DIFF
--- a/front/src/components/templates/SessionShow.tsx
+++ b/front/src/components/templates/SessionShow.tsx
@@ -4,6 +4,7 @@ import { PaletteLevel } from '@mui/material'
 import sessionContents from '../../functions/constants/common/sessionContent.json'
 import theme from '../../../theme/theme'
 import { BasicChip } from '../uis/BasicChip'
+import { PLATFORM, PASSION } from '../../functions/constants/common/sessionInfo'
 
 const CustomContainer = styled.div`
   padding: 30px 0;
@@ -73,21 +74,21 @@ export const SessionShow = () => {
   return (
     <CustomContainer>
       <SessionTitle palette={Passion[sessionContent?.passionLevel!]}>
-        {sessionContent?.title ?? 'タイトルなし'}
+        {sessionContent?.title ? sessionContent.title : 'タイトルなし'}
       </SessionTitle>
       <ContentContainer>
         <ContentWrapper>
           <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>ユーザー名</ContentTitle>
           <Content>
-            <p>{sessionContent?.userName ?? '名無しのユーザーさん'}</p>
+            <p>{sessionContent?.userName ? sessionContent.userName : '名無しのユーザーさん'}</p>
           </Content>
         </ContentWrapper>
         <ContentWrapper>
           <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>タグ</ContentTitle>
           <Content>
-            {sessionContent?.tags?.map((tag, index) => <BasicChip key={index} text={tag} />) ?? (
-              <BasicChip text="タグなし" />
-            )}
+            {sessionContent?.tags?.map((tag, index) =>
+              tag ? <BasicChip key={index} text={tag} /> : <BasicChip key={index} text="タグなし" />
+            ) ?? <BasicChip text="タグなし" />}
           </Content>
         </ContentWrapper>
         <ContentWrapper>
@@ -113,7 +114,7 @@ export const SessionShow = () => {
         <ContentWrapper className="-full-width">
           <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>コメント</ContentTitle>
           <Content>
-            <p>{sessionContent?.content ?? 'コメントなし'}</p>
+            <p>{sessionContent?.content ? sessionContent.content : 'コメントなし'}</p>
           </Content>
         </ContentWrapper>
       </ContentContainer>

--- a/front/src/components/templates/SessionShow.tsx
+++ b/front/src/components/templates/SessionShow.tsx
@@ -2,9 +2,8 @@ import { useRouter } from 'next/router'
 import styled from '@emotion/styled'
 import { PaletteLevel } from '@mui/material'
 import sessionContents from '../../functions/constants/common/sessionContent.json'
-import theme from '../../../theme/theme'
 import { BasicChip } from '../uis/BasicChip'
-import { PLATFORM, PASSION } from '../../functions/constants/common/sessionInfo'
+import { PLATFORM, PASSION_COLOR, PASSION_WORD } from '../../functions/constants/common/sessionInfo'
 
 const CustomContainer = styled.div`
   padding: 30px 0;
@@ -54,16 +53,6 @@ type SessionSectionStyleProps = {
   palette?: PaletteLevel
 }
 
-interface PassionInterFace {
-  [key: number]: PaletteLevel
-}
-
-const Passion: PassionInterFace = {
-  1: theme.palette.customBlue,
-  2: theme.palette.customGreen,
-  3: theme.palette.customRed,
-}
-
 export const SessionShow = () => {
   const router = useRouter()
   const { sessionId } = router.query
@@ -73,18 +62,18 @@ export const SessionShow = () => {
 
   return (
     <CustomContainer>
-      <SessionTitle palette={Passion[sessionContent?.passionLevel!]}>
+      <SessionTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>
         {sessionContent?.title ? sessionContent.title : 'タイトルなし'}
       </SessionTitle>
       <ContentContainer>
         <ContentWrapper>
-          <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>ユーザー名</ContentTitle>
+          <ContentTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>ユーザー名</ContentTitle>
           <Content>
             <p>{sessionContent?.userName ? sessionContent.userName : '名無しのユーザーさん'}</p>
           </Content>
         </ContentWrapper>
         <ContentWrapper>
-          <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>タグ</ContentTitle>
+          <ContentTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>タグ</ContentTitle>
           <Content>
             {sessionContent?.tags?.map((tag, index) =>
               tag ? <BasicChip key={index} text={tag} /> : <BasicChip key={index} text="タグなし" />
@@ -92,27 +81,25 @@ export const SessionShow = () => {
           </Content>
         </ContentWrapper>
         <ContentWrapper>
-          <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>プラットフォーム</ContentTitle>
+          <ContentTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>プラットフォーム</ContentTitle>
           <Content>
-            {/* TODO:Enum作成 */}
-            <p>{sessionContent?.platform}</p>
+            <p>{PLATFORM[sessionContent?.platform!]}</p>
           </Content>
         </ContentWrapper>
         <ContentWrapper>
-          <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>URL（仮）</ContentTitle>
+          <ContentTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>URL（仮）</ContentTitle>
           <Content>
             <p>{sessionContent?.platform_content}</p>
           </Content>
         </ContentWrapper>
         <ContentWrapper>
-          <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>ガチ度</ContentTitle>
+          <ContentTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>ガチ度</ContentTitle>
           <Content>
-            {/* TODO:Enum作成 */}
-            <p>{sessionContent?.passionLevel}</p>
+            <p>{PASSION_WORD[sessionContent?.passionLevel!]}</p>
           </Content>
         </ContentWrapper>
         <ContentWrapper className="-full-width">
-          <ContentTitle palette={Passion[sessionContent?.passionLevel!]}>コメント</ContentTitle>
+          <ContentTitle palette={PASSION_COLOR[sessionContent?.passionLevel!]}>コメント</ContentTitle>
           <Content>
             <p>{sessionContent?.content ? sessionContent.content : 'コメントなし'}</p>
           </Content>

--- a/front/src/components/uis/SessionCard.tsx
+++ b/front/src/components/uis/SessionCard.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { Card, CardHeader, Avatar, CardContent, PaletteLevel } from '@mui/material'
 import { BasicChip } from './BasicChip'
 import theme from '../../../theme/theme'
+import { PASSION_COLOR } from '@/functions/constants/common/sessionInfo'
 
 const CustomCard = styled(Card)<SessionCardStyleProps>`
   width: ${({ width }) => width};
@@ -38,15 +39,15 @@ type SessionCardStyleProps = {
   palette?: PaletteLevel
 }
 
-interface PassionInterFace {
-  [key: number]: PaletteLevel
-}
+// interface PassionInterFace {
+//   [key: number]: PaletteLevel
+// }
 
-const Passion: PassionInterFace = {
-  1: theme.palette.customBlue,
-  2: theme.palette.customGreen,
-  3: theme.palette.customRed,
-}
+// const Passion: PassionInterFace = {
+//   1: theme.palette.customBlue,
+//   2: theme.palette.customGreen,
+//   3: theme.palette.customRed,
+// }
 
 type SessionCardProps = {
   userName?: string | null
@@ -72,7 +73,7 @@ export const SessionCard: React.FC<SessionCardProps> = ({
   // TODO：日付フォーマットの実装
   const convertDate = String(created_at)
   return (
-    <CustomCard width={width} palette={Passion[passionLevel]}>
+    <CustomCard width={width} palette={PASSION_COLOR[passionLevel]}>
       <CustomCardHeader
         //   TODO：アップロードした画像との繋ぎ込み
         avatar={<Avatar aria-label="recipe">{avatarChar}</Avatar>}
@@ -84,13 +85,25 @@ export const SessionCard: React.FC<SessionCardProps> = ({
         {tags ? (
           tags?.map((tag, i) =>
             tag ? (
-              <BasicChip key={i} className="-text-white" text={tag} size="small" palette={Passion[passionLevel]} />
+              <BasicChip
+                key={i}
+                className="-text-white"
+                text={tag}
+                size="small"
+                palette={PASSION_COLOR[passionLevel]}
+              />
             ) : (
-              <BasicChip key={i} className="-text-white" text="タグなし" size="small" palette={Passion[passionLevel]} />
+              <BasicChip
+                key={i}
+                className="-text-white"
+                text="タグなし"
+                size="small"
+                palette={PASSION_COLOR[passionLevel]}
+              />
             )
           )
         ) : (
-          <BasicChip className="-text-white" text="タグなし" size="small" palette={Passion[passionLevel]} />
+          <BasicChip className="-text-white" text="タグなし" size="small" palette={PASSION_COLOR[passionLevel]} />
         )}
       </CustomCardContent>
       <CustomCardContent className="-small">{content ? content : 'コメントなし'}</CustomCardContent>

--- a/front/src/functions/constants/common/sessionInfo.ts
+++ b/front/src/functions/constants/common/sessionInfo.ts
@@ -1,0 +1,39 @@
+import { PaletteLevel } from '@mui/material'
+import theme from '../../../../theme/theme'
+
+// プラットフォーム
+interface PlatformType {
+  'Google Meet': string
+  Skype: string
+  Slack: string
+}
+
+export const PLATFORM: { [key: number]: keyof PlatformType } = {
+  0: 'Google Meet',
+  1: 'Skype',
+  2: 'Slack',
+}
+
+// ガチ度(カラーパターン)
+interface PassionInterFace {
+  [key: number]: PaletteLevel
+}
+
+export const PASSION_COLOR: PassionInterFace = {
+  1: theme.palette.customBlue,
+  2: theme.palette.customGreen,
+  3: theme.palette.customRed,
+}
+
+// ガチ度(文言)
+interface PassionWordType {
+  まったり: string
+  そこそこ: string
+  ガチ: string
+}
+
+export const PASSION_WORD: { [key: number]: keyof PassionWordType } = {
+  1: 'まったり',
+  2: 'そこそこ',
+  3: 'ガチ',
+}


### PR DESCRIPTION
- ガチ度・プラットフォームデータはサーバーから数値データとして渡ってくる想定なので、数値を文言に変換するための定数を作成した
- ついでにカラーパターンもcontainsに定数化
- 詳細ページとセッションカードに定数を適用